### PR TITLE
Scrub newlines from header values

### DIFF
--- a/lib/rack/reverse_proxy.rb
+++ b/lib/rack/reverse_proxy.rb
@@ -20,7 +20,7 @@ module Rack
       headers = Rack::Utils::HeaderHash.new
       env.each { |key, value|
         if !value.nil? and key =~ /HTTP_(.*)/
-          headers[$1] = value
+          headers[$1] = value.gsub("\n", "")
         end
       }
       headers['HOST'] = uri.host if all_opts[:preserve_host]


### PR DESCRIPTION
The way this packs the auth header means that over a given length, it
will include newlines

https://github.com/brynary/rack-test/blob/master/lib/rack/test.rb#L162
